### PR TITLE
Workaround for fixture loading

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -456,7 +456,7 @@ module ActiveRecord
         end
 
         def build_fixture_sql(fixtures, table_name)
-          columns = schema_cache.columns_hash(table_name)
+          columns = schema_cache.columns_hash(table_name).reject { |_, c| c.virtual? }
 
           values_list = fixtures.map do |fixture|
             fixture = fixture.stringify_keys

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -69,5 +69,9 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "length\(\(name\)::text\)", stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "octet_length\(\(name\)::text\)", stored: true$/i, output)
     end
+
+    def test_build_fixture_sql
+      ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns)
+    end
   end
 end

--- a/activerecord/test/fixtures/virtual_columns.yml
+++ b/activerecord/test/fixtures/virtual_columns.yml
@@ -1,0 +1,5 @@
+one:
+  name: hello
+
+two:
+  name: world


### PR DESCRIPTION
PG will fail miserably when loading fixtures for tables with generated columns. Here are some extras towards your PR.
```ruby
PostgresqlVirtualColumnTest#test_build_fixture_sql:
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  cannot insert into column "upper_name"
DETAIL:  Column "upper_name" is a generated column.
```